### PR TITLE
ci: use node version 19.5.0 instead of 19.6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Unit and Integration
     strategy:
       matrix:
-        version: [16, 18, 19]
+        version: [16, 18, 19.5.0]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Switching back to node 19.5.0. With node 19.6.0 test execution fails `The "payload" argument must be of type object.` Reason not clear yet. 