### PR TITLE
ci(fosstars): use OpenUI5 bot for rating commit

### DIFF
--- a/.github/workflows/fosstars-project-report.yml
+++ b/.github/workflows/fosstars-project-report.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: SAP/fosstars-rating-core-action@v1.9.1
         with:
           report-branch: fosstars-report
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ secrets.GH_OPENUI5BOT }}"


### PR DESCRIPTION
Use the OpenUI5 bot instead of the generic github actions user for committing the fosstar results