### PR TITLE
ci(dependabot): use ci prefix in commit message for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  commit-message:
+    prefix: "ci(github-actions)"
 - package-ecosystem: npm
   directory: "/"
   schedule:


### PR DESCRIPTION
Use `ci(github-actions)` prefix for dependencies updates