### PR TITLE
ci(release-please): activate npm publish by removing dry-run argument

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,4 +35,4 @@ jobs:
         NODE_AUTH_TOKEN: ${{secrets.NPM_OPENUI5BOT}}
       run: |
         cd ${{ matrix.path_released }}
-        npm publish --dry-run --workspaces false
+        npm publish --workspaces false


### PR DESCRIPTION
Activates the npm publish.

Pre-Conditions:
- [x] UA review is finished
- [x] repository is public.
