### PR TITLE
ci(release-please): add auth info to package specific npm config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,4 +35,5 @@ jobs:
         NPM_TOKEN: ${{secrets.NPM_UI5BOT}}
       run: |
         cd ${{ matrix.path_released }}
+        npm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
         npm publish --workspaces false

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
 # Enforce public npm registry
 registry=https://registry.npmjs.org/
 lockfile-version=3
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Adds the auth config to the package and not on the root level.