### PR TITLE
ci(fosstars): use new git user options and default gh token

### DIFF
--- a/.github/workflows/fosstars-project-report.yml
+++ b/.github/workflows/fosstars-project-report.yml
@@ -10,7 +10,9 @@ jobs:
     name: "Security rating"
     steps:
       - uses: actions/checkout@v3
-      - uses: SAP/fosstars-rating-core-action@v1.10.0
+      - uses: SAP/fosstars-rating-core-action@v1.11.0
         with:
           report-branch: fosstars-report
-          token: "${{ secrets.GH_OPENUI5BOT }}"
+          git-user-name: "OpenUI5 Bot"
+          git-user-email: "openui5@sap.com"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With https://github.com/SAP/fosstars-rating-core-action/releases/tag/v1.11.0 it is possible to specify a dedicated git committer.

In the past I thought using a custom token would do the job but thats only the case when the github API is used inside the action. Thats not the case for fosstars so token can be reset to the default github token.