### PR TITLE
fix(middleware-code-coverage): fix ping endpoint middleware version

### DIFF
--- a/packages/middleware-code-coverage/lib/middleware.js
+++ b/packages/middleware-code-coverage/lib/middleware.js
@@ -42,6 +42,8 @@ export default async function({log, middlewareUtil, options={}, resources}) {
 		...generalConfig
 	} = config;
 
+	const {version: middlewareVersion} = await readJsonFile(new URL("../package.json", import.meta.url));
+
 	// Instrumenter instance
 	const instrumenter = createInstrumenter(instrumenterConfig);
 	const instrument = promisify(instrumenter.instrument.bind(instrumenter));
@@ -84,8 +86,9 @@ export default async function({log, middlewareUtil, options={}, resources}) {
 	 * Endpoint to check for middleware existence
 	 */
 	router.get("/.ui5/coverage/ping", async (req, res) => {
-		const {version} = await readJsonFile("./package.json");
-		res.json({version});
+		res.json({
+			version: middlewareVersion
+		});
 	});
 
 	/**


### PR DESCRIPTION
This change ensures that the correct package.json is read to determine
the middleware version.
Previously the package.json relative to the `cwd` was used.

Reading the version is only needed once per instance, not per request.
