### PR TITLE
ci(test): use latest node version 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Unit and Integration
     strategy:
       matrix:
-        version: [16, 18, 19.5.0]
+        version: [16, 18, 19]
         os: [ubuntu-22.04, windows-2022, macos-12]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Unit and Integration
     strategy:
       matrix:
-        version: [16, 18, 19.9.0]
+        version: [16, 18, 20]
         os: [ubuntu-22.04, windows-2022, macos-12]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Unit and Integration
     strategy:
       matrix:
-        version: [16, 18, 19]
+        version: [16, 18, 19.9.0]
         os: [ubuntu-22.04, windows-2022, macos-12]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Test execution fails for node v19 because of ava (https://github.com/avajs/ava/pull/3193).
node v20 is the new current version and runs fine.