### PR TITLE
Revert "build(deps): bump xml2js from 0.4.23 to 0.5.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7367,9 +7367,9 @@
 			}
 		},
 		"node_modules/xml2js": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
 			"dependencies": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"
@@ -7519,7 +7519,7 @@
 				"istanbul-reports": "^3.1.5",
 				"router": "^1.3.8",
 				"serve-static": "^1.15.0",
-				"xml2js": "^0.5.0"
+				"xml2js": "^0.4.23"
 			},
 			"devDependencies": {
 				"@istanbuljs/esm-loader-hook": "^0.2.0",

--- a/packages/middleware-code-coverage/package.json
+++ b/packages/middleware-code-coverage/package.json
@@ -36,7 +36,7 @@
 		"istanbul-reports": "^3.1.5",
 		"router": "^1.3.8",
 		"serve-static": "^1.15.0",
-		"xml2js": "^0.5.0"
+		"xml2js": "^0.4.23"
 	},
 	"devDependencies": {
 		"@istanbuljs/esm-loader-hook": "^0.2.0",


### PR DESCRIPTION
Reverts SAP/ui5-tooling-extensions#72

Reverting this PR to submit it again with the correct type `fix`, so that a patch release is created.