### PR TITLE
fix(middleware-code-coverage): ignore excludes marked as 'external'

### DIFF
--- a/packages/middleware-code-coverage/lib/util.js
+++ b/packages/middleware-code-coverage/lib/util.js
@@ -158,6 +158,12 @@ async function excludePatterns(resources) {
 			for (let j = 0; j < oCoverage.exclude.length; j++) {
 				const oExclude = oCoverage.exclude[j];
 
+				// Excludes marked with 'external="true"' are intended for a library local
+				// instrumentation only and should be ignored in a multi-library scenario
+				if (oExclude.$.external === "true") {
+					continue;
+				}
+
 				let sPattern = oExclude.$.name;
 
 				// normalize the pattern

--- a/packages/middleware-code-coverage/test/unit/lib/util.js
+++ b/packages/middleware-code-coverage/test/unit/lib/util.js
@@ -138,6 +138,7 @@ test("createInstrumentationConfig: .library excludes", async (t) => {
 			<exclude name="/my-file" />
 			<exclude name="ui5.customlib.utils." />
 			<exclude name="ui5.customlib.Control1" />
+			<exclude name="sap.m." external="true"/>
 		</jscoverage>
 	</appData>
 </library>`;


### PR DESCRIPTION
The middleware collects and merges coverage exclude patterns from the .library files of all reachable library projects. If an exclude pattern is marked with `external="true"`, it should be ignored by the merge as such excludes are only intended for a library local instrumentation.
