### PR TITLE
ci(test.yml): use macos-13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         version: [16, 18, 20]
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
 


### PR DESCRIPTION
`macos-13` is available https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/