### PR TITLE
docs(readme.md): use default branch of sample app

### DIFF
--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -10,7 +10,7 @@ This UI5 Tooling Server Middleware offers code instrumentation powered by [Istan
 
 ## Sample
 
-You find this middleware in action in an adjusted version of the [OpenUI5 Sample App (branch `middleware-code-coverage`)](https://github.com/SAP/openui5-sample-app/tree/middleware-code-coverage).
+You find this middleware in action in the [OpenUI5 Sample App](https://github.com/SAP/openui5-sample-app).
 
 ## Requirements
 


### PR DESCRIPTION
As middleware-code-coverage is available in the default branch of the openui5 sample app with https://github.com/SAP/openui5-sample-app/commit/1ee9651f568ad280a5aba4aa7b7fea814ce24557 adjusting the documentation here.