### PR TITLE
ci(dependabot): use 'deps' for commit message header for deps updates

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -9,6 +9,7 @@
 			[
 				"build",
 				"ci",
+				"deps",
 				"docs",
 				"feat",
 				"fix",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,5 @@ updates:
   - flovogt
   versioning-strategy: increase
   commit-message:
-    prefix: "build(deps)"
+    prefix: "deps"
     prefix-development: "build(deps-dev)"


### PR DESCRIPTION
`release-please` creates a release PR when the commit message starts with "feat", "fix" or "deps". See https://github.com/googleapis/release-please/blob/bdd9b0158ce79d958da01ebf54cb6b07925bc125/README.md?plain=1#L145