### PR TITLE
ci(release-please): activate release-please for 'deps' commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,61 @@
 {
-    "packages": {
-        "packages/middleware-code-coverage": {}
-    },
-    "pull-request-header": ":tractor: New release prepared",
-    "pull-request-title-pattern": "release:${component} v${version}",
-    "separate-pull-requests": true
+	"packages": {
+		"packages/middleware-code-coverage": {}
+	},
+	"pull-request-header": ":tractor: New release prepared",
+	"pull-request-title-pattern": "release:${component} v${version}",
+	"separate-pull-requests": true,
+	"changelog-sections": [
+		{
+			"type": "feat",
+			"section": "Features"
+		},
+		{
+			"type": "fix",
+			"section": "Bug Fixes"
+		},
+		{
+			"type": "perf",
+			"section": "Performance Improvements"
+		},
+		{
+			"type": "deps",
+			"section": "Dependencies"
+		},
+		{
+			"type": "docs",
+			"section": "Documentation",
+			"hidden": true
+		},
+		{
+			"type": "style",
+			"section": "Styles",
+			"hidden": true
+		},
+		{
+			"type": "refactor",
+			"section": "Code Refactoring",
+			"hidden": true
+		},
+		{
+			"type": "test",
+			"section": "Tests",
+			"hidden": true
+		},
+		{
+			"type": "build",
+			"section": "Automation",
+			"hidden": true
+		},
+		{
+			"type": "ci",
+			"section": "Continuous Integration",
+			"hidden": true
+		},
+		{
+			"type": "release",
+			"section": "Release",
+			"hidden": true
+		}
+	]
 }


### PR DESCRIPTION
With https://github.com/SAP/ui5-tooling-extensions/pull/116 we have enabled `deps` as a valid commit message scope but `release-please` requires separate config.

See https://github.com/google-github-actions/release-please-action/issues/804