### PR TITLE
build: allow commit messages with scope 'revert' for reverts

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -16,6 +16,7 @@
 				"perf",
 				"refactor",
 				"release",
+				"revert",
 				"style",
 				"test"
 			]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,10 @@
 			"section": "Dependencies"
 		},
 		{
+			"type": "revert",
+			"section": "Reverts"
+		},
+		{
 			"type": "docs",
 			"section": "Documentation",
 			"hidden": true


### PR DESCRIPTION
Allow usage of `revert` scope.

Example:

````
revert: "fix(moduleA): use optionB"

Refs: 676104e, a215868
````