### PR TITLE
feat(middleware-code-coverage): allow coverage watermarks configuration via frontend

### DIFF
--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -189,7 +189,7 @@ You can override [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f
 ...
 ```
 
-## How it works
+## How It Works
 
 The middleware adds an HTTP endpoint to the development server. Information about the endpoints can be found in the [API document](./docs/API.md).
 

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -191,7 +191,7 @@ You can override [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f
 
 ## How It Works
 
-The middleware adds an HTTP endpoint to the development server. Information about the endpoints can be found in the [API document](./docs/API.md).
+The middleware adds an HTTP endpoint to the development server. For more information about the endpoints, see the [API document](./docs/API.md).
 
 The custom middleware intercepts every `.js`-file before it is sent to the client. The file is then instrumented on the fly, including the dynamic creation of a `sourcemap`.
 

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -113,7 +113,12 @@ npm install @ui5/middleware-code-coverage --save-dev
         <script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
         <script src="../../resources/sap/ui/qunit/qunit-coverage-istanbul.js"
           data-sap-ui-cover-only="ui5/sample/"
-          data-sap-ui-cover-never="ui5/sample/test/"></script>
+          data-sap-ui-cover-never="ui5/sample/test/"
+          data-sap-ui-cover-watermarks-statements="[90,95]"
+          data-sap-ui-cover-watermarks-functions="[90,95]"
+          data-sap-ui-cover-watermarks-branches="[90,95]"
+          data-sap-ui-cover-watermarks-lines="[90,95]"
+      ></script>
         <script src="../../resources/sap/ui/thirdparty/sinon.js"></script>
         <script src="../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
 
@@ -224,7 +229,7 @@ Sends `__coverage__` data to the middleware. A static report is generated with t
 
 **Note:** Report types could be defined and limited via the middleware's configuration.
 
-**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (Available since OpenUI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones.
+**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (Available since OpenUI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones. On how to use it in OpenUI5 HTML test pages, please refer to the [Usage](#usage) section of this document.
 
 **Example:**
 

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -224,7 +224,7 @@ Sends `__coverage__` data to the middleware. A static report is generated with t
 
 **Note:** Report types could be defined and limited via the middleware's configuration.
 
-**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported. Frontend defined settings take precedence over default or `ui5.yaml` configured ones.
+**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (Available since OpenUI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones.
 
 **Example:**
 

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -193,7 +193,7 @@ You can override [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f
 
 The middleware adds an HTTP endpoint to the development server. For more information about the endpoints, see the [API document](./docs/API.md).
 
-The custom middleware intercepts every `.js`-file before it is sent to the client. The file is then instrumented on the fly, including the dynamic creation of a `sourcemap`.
+The custom middleware intercepts every `.js`-file before it is sent to the client. The file is then instrumented on the fly, which includes the dynamic creation of a `sourcemap`.
 
 The instrumented code and the `sourcemap` are subsequently delivered to the client instead of the original `.js`-file.
 

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -199,7 +199,7 @@ The instrumented code and the `sourcemap` are subsequently delivered to the clie
 
 ## Integration
 
-The middleware is integrated into OpenUI5 out of the box, but it is not limited just to it. With the [configuration](#configuration) and the [public API](./docs/API.md), developers could set up the middleware to suit their projects' needs.
+The middleware is integrated into OpenUI5 out of the box, but you are not limited by this. With the [configuration](#configuration) and the [public API](./docs/API.md), you can set up the middleware to suit your projects' needs.
 
 ### OpenUI5 QUnit Integration
 

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -173,7 +173,7 @@ Defaults to:
 
 ### Frontend Configuration
 
-It is possible to override [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) (since UI5 1.119.0) via data attributes in `qunit-coverage-istanbul.js`'s script tag.
+You can override [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) (since UI5 1.119.0) via data attributes in the script tag for `qunit-coverage-istanbul.js`':
 
 ```diff html title="unitTests.qunit.html"
 ...

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -229,56 +229,6 @@ The middleware is integrated into OpenUI5 out of the box, but it is not limited 
 
 The `qunit-coverage-istanbul.js` (part of `sap.ui.core` library) file requests the instrumented source files by the middleware. While the tests are running, `qunit-coverage-istanbul.js` takes care of collecting and storing the coverage records into the `window.__coverage__` global variable. After the tests are executed, `qunit-coverage-istanbul.js` sends this data to the middleware, which then generates the code coverage report. Afterwards, the code coverage is displayed on the test page.
 
-### Custom Integration
-
-Below is an example of a sample scenario to integrate UI5 Middleware Code Coverage.
-
-```js
-// A module in the browser
-
-const isMiddlewareAvailable = await fetch("/.ui5/coverage/ping", {
-  method: "GET",
-});
-
-if (isMiddlewareAvailable) {
-  
-  const generatedReports = await fetch("/.ui5/coverage/report", {
-    method: "POST",
-    body: JSON.stringify({
-      coverage: window.__coverage__,
-      watermarks: { // Optional: report setting
-        statements: [75, 90],
-        functions: [75, 90],
-        branches: [75, 90],
-        lines: [75, 90]
-      }
-    }),
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-
-  // Extract the html report from the list of reports
-  const htmlReport = generatedReports.availableReports.find(
-    (report) => report.report === "html"
-  );
-  
-  if (htmlReport) {
-    
-    const body = document.body;
-    const iFrameElem = document.createElement("iframe");
-    
-    iFrameElem.src = "/.ui5/coverage/report/" + htmlReport.destination;
-    iFrameElem.style.border = "none";
-    iFrameElem.style.width = "100%";
-    iFrameElem.style.height = "100vh";
-    iFrameElem.sandbox = "allow-scripts";
-
-    body.appendChild(iFrameElem);
-    
-  }
-}
-```
 
 ## Code of Conduct
 

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -224,12 +224,22 @@ Sends `__coverage__` data to the middleware. A static report is generated with t
 
 **Note:** Report types could be defined and limited via the middleware's configuration.
 
+**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported. Frontend defined settings take precedence over default or `ui5.yaml` configured ones.
+
 **Example:**
 
 ```js
 fetch("/.ui5/coverage/report", {
   method: "POST",
-  body: JSON.stringify(window.__coverage__),
+  body: JSON.stringify({
+    coverage: window.__coverage__,
+    watermarks: { // Optional: report setting
+      statements: [75, 90],
+      functions: [75, 90],
+      branches: [75, 90],
+      lines: [75, 90]
+    }
+  }),
   headers: {
     "Content-Type": "application/json",
   },

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -171,7 +171,7 @@ Defaults to:
 }
 ```
 
-### Frontend Configuration
+### Front-End Configuration
 
 You can override [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) (since UI5 1.119.0) via data attributes in the script tag for `qunit-coverage-istanbul.js`':
 

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -93,7 +93,7 @@ npm install @ui5/middleware-code-coverage --save-dev
 
     **New:**
 
-    ```html title="unitTests.qunit.html"
+    ```diff html title="unitTests.qunit.html"
     <!DOCTYPE html>
     <html>
     <head>
@@ -111,10 +111,10 @@ npm install @ui5/middleware-code-coverage --save-dev
 
         <script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
         <script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
-        <script src="../../resources/sap/ui/qunit/qunit-coverage-istanbul.js"
+    -   <script src="../../resources/sap/ui/qunit/qunit-coverage.js"
+    +   <script src="../../resources/sap/ui/qunit/qunit-coverage-istanbul.js"
           data-sap-ui-cover-only="ui5/sample/"
-          data-sap-ui-cover-never="ui5/sample/test/"
-      ></script>
+          data-sap-ui-cover-never="ui5/sample/test/"></script>
         <script src="../../resources/sap/ui/thirdparty/sinon.js"></script>
         <script src="../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
 
@@ -173,44 +173,20 @@ Defaults to:
 
 ### Frontend Configuration
 
-It is possible to override [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) (since OpenUI5 1.119.0) via data attributes in `qunit-coverage-istanbul.js`'s script tag.
+It is possible to override [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) (since UI5 1.119.0) via data attributes in `qunit-coverage-istanbul.js`'s script tag.
 
-```html title="unitTests.qunit.html"
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>Unit tests for OpenUI5 App</title>
+```diff html title="unitTests.qunit.html"
+...
 
-    <script id="sap-ui-bootstrap" src="../../resources/sap-ui-core.js"
-      data-sap-ui-theme="sap_horizon"
-      data-sap-ui-resourceroots='{
-        "ui5.sample": "../../"
-      }' data-sap-ui-language="EN" data-sap-ui-async="true">
-    </script>
-
-    <link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css">
-
-    <script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
-    <script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
     <script src="../../resources/sap/ui/qunit/qunit-coverage-istanbul.js"
       data-sap-ui-cover-only="ui5/sample/"
       data-sap-ui-cover-never="ui5/sample/test/"
-      data-sap-ui-cover-watermarks-statements="[90,95]"
-      data-sap-ui-cover-watermarks-functions="[90,95]"
-      data-sap-ui-cover-watermarks-branches="[90,95]"
-      data-sap-ui-cover-watermarks-lines="[90,95]"
-  ></script>
-    <script src="../../resources/sap/ui/thirdparty/sinon.js"></script>
-    <script src="../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
++     data-sap-ui-cover-watermarks-statements="[90,95]"
++     data-sap-ui-cover-watermarks-functions="[90,95]"
++     data-sap-ui-cover-watermarks-branches="[90,95]"
++     data-sap-ui-cover-watermarks-lines="[90,95]"></script>
 
-    <script src="unitTests.qunit.js"></script>
-</head>
-<body>
-    <div id="qunit"></div>
-    <div id="qunit-fixture"></div>
-</body>
-</html>
+...
 ```
 
 ## How it works

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -282,7 +282,15 @@ if (isMiddlewareAvailable) {
   
   const generatedReports = await fetch("/.ui5/coverage/report", {
     method: "POST",
-    body: JSON.stringify(window.__coverage__),
+    body: JSON.stringify({
+      coverage: window.__coverage__,
+      watermarks: { // Optional: report setting
+        statements: [75, 90],
+        functions: [75, 90],
+        branches: [75, 90],
+        lines: [75, 90]
+      }
+    }),
     headers: {
       "Content-Type": "application/json",
     },

--- a/packages/middleware-code-coverage/README.md
+++ b/packages/middleware-code-coverage/README.md
@@ -114,10 +114,6 @@ npm install @ui5/middleware-code-coverage --save-dev
         <script src="../../resources/sap/ui/qunit/qunit-coverage-istanbul.js"
           data-sap-ui-cover-only="ui5/sample/"
           data-sap-ui-cover-never="ui5/sample/test/"
-          data-sap-ui-cover-watermarks-statements="[90,95]"
-          data-sap-ui-cover-watermarks-functions="[90,95]"
-          data-sap-ui-cover-watermarks-branches="[90,95]"
-          data-sap-ui-cover-watermarks-lines="[90,95]"
       ></script>
         <script src="../../resources/sap/ui/thirdparty/sinon.js"></script>
         <script src="../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
@@ -175,98 +171,59 @@ Defaults to:
 }
 ```
 
+### Frontend Configuration
+
+It is possible to override [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) (since OpenUI5 1.119.0) via data attributes in `qunit-coverage-istanbul.js`'s script tag.
+
+```html title="unitTests.qunit.html"
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Unit tests for OpenUI5 App</title>
+
+    <script id="sap-ui-bootstrap" src="../../resources/sap-ui-core.js"
+      data-sap-ui-theme="sap_horizon"
+      data-sap-ui-resourceroots='{
+        "ui5.sample": "../../"
+      }' data-sap-ui-language="EN" data-sap-ui-async="true">
+    </script>
+
+    <link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css">
+
+    <script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
+    <script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
+    <script src="../../resources/sap/ui/qunit/qunit-coverage-istanbul.js"
+      data-sap-ui-cover-only="ui5/sample/"
+      data-sap-ui-cover-never="ui5/sample/test/"
+      data-sap-ui-cover-watermarks-statements="[90,95]"
+      data-sap-ui-cover-watermarks-functions="[90,95]"
+      data-sap-ui-cover-watermarks-branches="[90,95]"
+      data-sap-ui-cover-watermarks-lines="[90,95]"
+  ></script>
+    <script src="../../resources/sap/ui/thirdparty/sinon.js"></script>
+    <script src="../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
+
+    <script src="unitTests.qunit.js"></script>
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+</body>
+</html>
+```
+
 ## How it works
 
-The middleware adds an HTTP endpoint to the development server.
+The middleware adds an HTTP endpoint to the development server. Information about the endpoints can be found in the [API document](./docs/API.md).
 
 The custom middleware intercepts every `.js`-file before it is sent to the client. The file is then instrumented on the fly, including the dynamic creation of a `sourcemap`.
 
 The instrumented code and the `sourcemap` are subsequently delivered to the client instead of the original `.js`-file.
 
-## API
-
-This REST API is the underlying foundation of the middleware.
-
-**Note:** The `/.ui5/` path is reserved for UI5 Core modules and must not be used for third-party modules.
-
----
-### GET `{path/to/resource}?instrument=true`
-
-A resource could be instrumented for code coverage by appending `?instrument=true` as a query parameter. **Note:** If a resource has already been excluded via `excludePatterns` in middleware's configuration, the query parameter is ignored.
-
-**Example:**
-
-```js
-// OpenUI5
-
-GET /resources/sap/m/ComboBox.js?instrument=true
-GET /resources/sap/m/ComboBoxBase.js?instrument=true
-GET /resources/sap/m/ComboBoxBaseRenderer.js?instrument=true
-GET /resources/sap/m/ComboBoxRenderer.js?instrument=true
-GET /resources/sap/m/ComboBoxTextField.js?instrument=true
-GET /resources/sap/m/ComboBoxTextFieldRenderer.js?instrument=true
-```
-
----
-
-### GET `/.ui5/coverage/ping`
-
-Healthcheck. Useful when checking for the middleware's existence.
-
-**Example:**
-
-```js
-fetch("/.ui5/coverage/ping", {
-  method: "GET",
-});
-```
-
----
-
-### POST `/.ui5/coverage/report`
-
-Sends `__coverage__` data to the middleware. A static report is generated with the provided data. Reports could be accessed via the `/.ui5/coverage/report/${reportType}` route. The available report types could be found [here](https://github.com/istanbuljs/istanbuljs/tree/73c25ce79f91010d1ff073aa6ff3fd01114f90db/packages/istanbul-reports/lib).  
-
-**Note:** Report types could be defined and limited via the middleware's configuration.
-
-**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (Available since OpenUI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones. On how to use it in OpenUI5 HTML test pages, please refer to the [Usage](#usage) section of this document.
-
-**Example:**
-
-```js
-fetch("/.ui5/coverage/report", {
-  method: "POST",
-  body: JSON.stringify({
-    coverage: window.__coverage__,
-    watermarks: { // Optional: report setting
-      statements: [75, 90],
-      functions: [75, 90],
-      branches: [75, 90],
-      lines: [75, 90]
-    }
-  }),
-  headers: {
-    "Content-Type": "application/json",
-  },
-});
-```
-
----
-
-### GET `/.ui5/coverage/report/${reportType}`
-
-Returns the generated report(s) from the last generation via the `/.ui5/coverage/report` route.
-
-**Example:**
-
-```js
-GET /.ui5/coverage/report/html
-GET /.ui5/coverage/report/lcov
-```
-
 ## Integration
 
-The middleware is integrated into OpenUI5 out of the box, but it is not limited just to it. With the configuration and the public API, developers could set up the middleware to suit their projects' needs.
+The middleware is integrated into OpenUI5 out of the box, but it is not limited just to it. With the [configuration](#configuration) and the [public API](./docs/API.md), developers could set up the middleware to suit their projects' needs.
 
 ### OpenUI5 QUnit Integration
 

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -1,0 +1,85 @@
+# API
+
+This REST API is the underlying foundation of the middleware.
+
+**Note:** The `/.ui5/` path is reserved for UI5 Core modules and must not be used for third-party modules.
+
+---
+### GET `{path/to/resource}?instrument=true`
+
+A resource could be instrumented for code coverage by appending `?instrument=true` as a query parameter. **Note:** If a resource has already been excluded via `excludePatterns` in middleware's configuration, the query parameter is ignored.
+
+**Example:**
+
+```js
+// OpenUI5
+
+GET /resources/sap/m/ComboBox.js?instrument=true
+GET /resources/sap/m/ComboBoxBase.js?instrument=true
+GET /resources/sap/m/ComboBoxBaseRenderer.js?instrument=true
+GET /resources/sap/m/ComboBoxRenderer.js?instrument=true
+GET /resources/sap/m/ComboBoxTextField.js?instrument=true
+GET /resources/sap/m/ComboBoxTextFieldRenderer.js?instrument=true
+```
+
+---
+
+### GET `/.ui5/coverage/ping`
+
+Healthcheck. Useful when checking for the middleware's existence.
+
+**Example:**
+
+```js
+fetch("/.ui5/coverage/ping", {
+  method: "GET",
+});
+```
+
+---
+
+### POST `/.ui5/coverage/report`
+
+Sends `__coverage__` data to the middleware. A static report is generated with the provided data. Reports could be accessed via the `/.ui5/coverage/report/${reportType}` route. The available report types could be found [here](https://github.com/istanbuljs/istanbuljs/tree/73c25ce79f91010d1ff073aa6ff3fd01114f90db/packages/istanbul-reports/lib).  
+
+**Note:** Report types could be defined and limited via the middleware's configuration.
+
+**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (Available since OpenUI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones. On how to use it in OpenUI5 HTML test pages, please refer to the [Usage](../README.md#usage) section of the main document.
+
+**Example:**
+
+```js
+fetch("/.ui5/coverage/report", {
+  method: "POST",
+  body: JSON.stringify({
+    coverage: window.__coverage__,
+    watermarks: { // Optional: report setting
+      statements: [75, 90],
+      functions: [75, 90],
+      branches: [75, 90],
+      lines: [75, 90]
+    }
+  }),
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+```
+
+---
+
+### GET `/.ui5/coverage/report/${reportType}`
+
+Returns the generated report(s) from the last generation via the `/.ui5/coverage/report` route.
+
+**Example:**
+
+```js
+GET /.ui5/coverage/report/html
+GET /.ui5/coverage/report/lcov
+```
+
+
+## Licensing
+
+Copyright 2023 SAP SE or an SAP affiliate company and UI5 Tooling Extensions contributors. Please see our [LICENSE.txt](../../LICENSE.txt) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available via the [REUSE tool](https://api.reuse.software/info/github.com/SAP/ui5-tooling-extensions).

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -79,6 +79,56 @@ GET /.ui5/coverage/report/html
 GET /.ui5/coverage/report/lcov
 ```
 
+## Custom Integration
+
+Below is an example of a sample scenario to integrate UI5 Middleware Code Coverage.
+
+```js
+// A module in the browser
+
+const isMiddlewareAvailable = await fetch("/.ui5/coverage/ping", {
+  method: "GET",
+});
+
+if (isMiddlewareAvailable) {
+  
+  const generatedReports = await fetch("/.ui5/coverage/report", {
+    method: "POST",
+    body: JSON.stringify({
+      coverage: window.__coverage__,
+      watermarks: { // Optional: report setting
+        statements: [75, 90],
+        functions: [75, 90],
+        branches: [75, 90],
+        lines: [75, 90]
+      }
+    }),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  // Extract the html report from the list of reports
+  const htmlReport = generatedReports.availableReports.find(
+    (report) => report.report === "html"
+  );
+  
+  if (htmlReport) {
+    
+    const body = document.body;
+    const iFrameElem = document.createElement("iframe");
+    
+    iFrameElem.src = "/.ui5/coverage/report/" + htmlReport.destination;
+    iFrameElem.style.border = "none";
+    iFrameElem.style.width = "100%";
+    iFrameElem.style.height = "100vh";
+    iFrameElem.sandbox = "allow-scripts";
+
+    body.appendChild(iFrameElem);
+    
+  }
+}
+```
 
 ## Licensing
 

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -7,7 +7,7 @@ This REST API is the underlying foundation of the middleware.
 ---
 ### GET `{path/to/resource}?instrument=true`
 
-A resource could be instrumented for code coverage by appending `?instrument=true` as a query parameter. **Note:** If a resource has already been excluded via `excludePatterns` in middleware's configuration, the query parameter is ignored.
+A resource could be instrumented for code coverage by appending `?instrument=true` as a query parameter. **Note:** If a resource has already been excluded via `excludePatterns` in the middleware's configuration, the query parameter is ignored.
 
 **Example:**
 

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -26,7 +26,7 @@ GET /resources/sap/m/ComboBoxTextFieldRenderer.js?instrument=true
 
 ### GET `/.ui5/coverage/ping`
 
-Healthcheck. Useful when checking for the middleware's existence.
+Health check. Useful when checking for the middleware's existence.
 
 **Example:**
 

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -42,7 +42,7 @@ fetch("/.ui5/coverage/ping", {
 
 Sends `__coverage__` data to the middleware. A static report is generated with the data provided. Reports can be accessed via the `/.ui5/coverage/report/${reportType}` route. The available report types can be found [here](https://github.com/istanbuljs/istanbuljs/tree/73c25ce79f91010d1ff073aa6ff3fd01114f90db/packages/istanbul-reports/lib).  
 
-**Note:** Report types could be defined and limited via the middleware's configuration.
+**Note:** Report types can be defined and limited via the middleware's configuration.
 
 **Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (available since UI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones. On how to use it in OpenUI5 HTML test pages, please refer to the [Frontend Configuration](../README.md#frontend-configuration) section of the main document.
 

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -44,7 +44,7 @@ Sends `__coverage__` data to the middleware. A static report is generated with t
 
 **Note:** Report types can be defined and limited via the middleware's configuration.
 
-**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (available since UI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones. On how to use it in OpenUI5 HTML test pages, please refer to the [Frontend Configuration](../README.md#frontend-configuration) section of the main document.
+**Note:** You can also provide report settings from the front end via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (available since UI5 1.119.0). Front end-defined settings take precedence over default or `ui5.yaml`-configured ones. For their usage in OpenUI5 HTML test pages, see the [Front-End Configuration](../README.md#frontend-configuration) section of the main document.
 
 **Example:**
 

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -70,7 +70,7 @@ fetch("/.ui5/coverage/report", {
 
 ### GET `/.ui5/coverage/report/${reportType}`
 
-Returns the generated report(s) from the last generation via the `/.ui5/coverage/report` route.
+Returns the most recent report(s) via the `/.ui5/coverage/report` route.
 
 **Example:**
 

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -81,7 +81,7 @@ GET /.ui5/coverage/report/lcov
 
 ## Custom Integration
 
-Below is an example of a sample scenario to integrate UI5 Middleware Code Coverage.
+Sample scenario to integrate UI5 Middleware Code Coverage:
 
 ```js
 // A module in the browser

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -129,7 +129,3 @@ if (isMiddlewareAvailable) {
   }
 }
 ```
-
-## Licensing
-
-Copyright 2023 SAP SE or an SAP affiliate company and UI5 Tooling Extensions contributors. Please see our [LICENSE.txt](../../LICENSE.txt) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available via the [REUSE tool](https://api.reuse.software/info/github.com/SAP/ui5-tooling-extensions).

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -44,7 +44,7 @@ Sends `__coverage__` data to the middleware. A static report is generated with t
 
 **Note:** Report types could be defined and limited via the middleware's configuration.
 
-**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (Available since OpenUI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones. On how to use it in OpenUI5 HTML test pages, please refer to the [Usage](../README.md#usage) section of the main document.
+**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (Available since OpenUI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones. On how to use it in OpenUI5 HTML test pages, please refer to the [Frontend Configuration](../README.md#frontend-configuration) section of the main document.
 
 **Example:**
 

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -40,7 +40,7 @@ fetch("/.ui5/coverage/ping", {
 
 ### POST `/.ui5/coverage/report`
 
-Sends `__coverage__` data to the middleware. A static report is generated with the provided data. Reports could be accessed via the `/.ui5/coverage/report/${reportType}` route. The available report types could be found [here](https://github.com/istanbuljs/istanbuljs/tree/73c25ce79f91010d1ff073aa6ff3fd01114f90db/packages/istanbul-reports/lib).  
+Sends `__coverage__` data to the middleware. A static report is generated with the data provided. Reports can be accessed via the `/.ui5/coverage/report/${reportType}` route. The available report types can be found [here](https://github.com/istanbuljs/istanbuljs/tree/73c25ce79f91010d1ff073aa6ff3fd01114f90db/packages/istanbul-reports/lib).  
 
 **Note:** Report types could be defined and limited via the middleware's configuration.
 

--- a/packages/middleware-code-coverage/docs/API.md
+++ b/packages/middleware-code-coverage/docs/API.md
@@ -44,7 +44,7 @@ Sends `__coverage__` data to the middleware. A static report is generated with t
 
 **Note:** Report types could be defined and limited via the middleware's configuration.
 
-**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (Available since OpenUI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones. On how to use it in OpenUI5 HTML test pages, please refer to the [Frontend Configuration](../README.md#frontend-configuration) section of the main document.
+**Note:** Also it is possible to set report settings from the frontend by providing them via the request body. Currently, only [`watermarks`](https://github.com/istanbuljs/nyc/blob/ab7c53b2f340b458789a746dff2abd3e2e4790c3/README.md#high-and-low-watermarks) are supported (available since UI5 1.119.0). Frontend defined settings take precedence over default or `ui5.yaml` configured ones. On how to use it in OpenUI5 HTML test pages, please refer to the [Frontend Configuration](../README.md#frontend-configuration) section of the main document.
 
 **Example:**
 

--- a/packages/middleware-code-coverage/lib/coverage-reporter.js
+++ b/packages/middleware-code-coverage/lib/coverage-reporter.js
@@ -35,8 +35,7 @@ export default async function(coverageData, config, resources, log) {
 
 	const coverageMap =
 		istanbulLibCoverage.createCoverageMap(globalCoverageMap);
-	const {report} = config;
-	const reportConfig = {...report};
+	const reportConfig = {...config.report};
 
 	// Frontend config for watermarks should take precedence if present.
 	reportConfig.watermarks = {...reportConfig.watermarks, ...watermarks};

--- a/packages/middleware-code-coverage/lib/coverage-reporter.js
+++ b/packages/middleware-code-coverage/lib/coverage-reporter.js
@@ -35,7 +35,8 @@ export default async function(coverageData, config, resources, log) {
 
 	const coverageMap =
 		istanbulLibCoverage.createCoverageMap(globalCoverageMap);
-	const {report: reportConfig} = config;
+	const {report} = config;
+	const reportConfig = {...report};
 
 	// Frontend config for watermarks should take precedence if present.
 	reportConfig.watermarks = {...reportConfig.watermarks, ...watermarks};

--- a/packages/middleware-code-coverage/lib/coverage-reporter.js
+++ b/packages/middleware-code-coverage/lib/coverage-reporter.js
@@ -12,7 +12,7 @@ import path from "node:path";
 /**
  * Reports the coverage
  *
- * @param {object} globalCoverageMap
+ * @param {object} coverageData
  * @param {*} config
  * @param {object} resources Resource collections
  * @param {module:@ui5/fs.AbstractReader} resources.all Reader or Collection to read resources of the
@@ -25,10 +25,20 @@ import path from "node:path";
  *  Logger instance of the custom middleware instance
  * @returns {@ui5/middleware-code-coverage/Coverage}
  */
-export default async function(globalCoverageMap, config, resources, log) {
+export default async function(coverageData, config, resources, log) {
+	let {coverage: globalCoverageMap, watermarks} = coverageData;
+
+	// For compatibility reasons with the old structure, we need first to check
+	// whether the "coverage" property is present in coverageData or use the
+	// whole coverageData object (old structure).
+	globalCoverageMap = globalCoverageMap || coverageData;
+
 	const coverageMap =
 		istanbulLibCoverage.createCoverageMap(globalCoverageMap);
 	const {report: reportConfig} = config;
+
+	// Frontend config for watermarks should take precedence if present.
+	reportConfig.watermarks = {...reportConfig.watermarks, ...watermarks};
 
 	// Get & stash code from the resources
 	// Later this would be needed to create the reports

--- a/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
+++ b/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
@@ -90,11 +90,7 @@ formatMessage(message) {
 
 test.beforeEach(async (t) => {
 	t.context.sinon = sinonGlobal.createSandbox();
-
-	t.context.libReport = await esmock("istanbul-lib-report");
-	t.context.coverageReporter = await esmock("../../../lib/coverage-reporter.js", {
-		"istanbul-lib-report": t.context.libReport
-	});
+	t.context.coverageReporter = await esmock("../../../lib/coverage-reporter.js");
 });
 
 test.afterEach.always((t) => {
@@ -193,7 +189,11 @@ test("Report Coverage: Log warning if resource can not be found", async (t) => {
 });
 
 test("Report Coverage: Fronted config for watermarks", async (t) => {
-	const {sinon, coverageReporter, libReport} = t.context;
+	const {sinon} = t.context;
+	const libReport = await esmock("istanbul-lib-report");
+	const coverageReporter = await esmock("../../../lib/coverage-reporter.js", {
+		"istanbul-lib-report": libReport
+	});
 	const reportSpy = sinon.spy(libReport, "createContext");
 
 	const modifiedWatermarks = {
@@ -222,7 +222,11 @@ test("Report Coverage: Fronted config for watermarks", async (t) => {
 });
 
 test("Report Coverage: Fronted config for watermarks- overwrite just some properties", async (t) => {
-	const {sinon, coverageReporter, libReport} = t.context;
+	const {sinon} = t.context;
+	const libReport = await esmock("istanbul-lib-report");
+	const coverageReporter = await esmock("../../../lib/coverage-reporter.js", {
+		"istanbul-lib-report": libReport
+	});
 	const reportSpy = sinon.spy(libReport, "createContext");
 
 	const config = await createInstrumentationConfig();

--- a/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
+++ b/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
@@ -194,8 +194,7 @@ test("Report Coverage: Fronted config for watermarks", async (t) => {
 		mockedResource
 	);
 
-	let lastReport = reportSpy.args.slice(-1);
-	let reportedWatermarks = lastReport[0][0].watermarks;
+	let reportedWatermarks = reportSpy.lastCall.args[0].watermarks;
 	t.deepEqual(watermarks, reportedWatermarks, "Watermarks got updated");
 
 	await coverageReporter(coverageData, config, mockedResource);

--- a/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
+++ b/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
@@ -199,7 +199,6 @@ test("Report Coverage: Fronted config for watermarks", async (t) => {
 
 	await coverageReporter(coverageData, config, mockedResource);
 
-	lastReport = reportSpy.args.slice(-1);
-	reportedWatermarks = lastReport[0][0].watermarks;
+	reportedWatermarks = reportSpy.lastCall.args[0].watermarks;
 	t.notDeepEqual(watermarks, reportedWatermarks, "Default watermarks got used");
 });

--- a/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
+++ b/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
@@ -188,7 +188,10 @@ test("Report Coverage: Log warning if resource can not be found", async (t) => {
 	t.deepEqual(report, expectedConfig);
 });
 
-test("Report Coverage: Fronted config for watermarks", async (t) => {
+// ESM import + sinon.spy on "istanbul-lib-report" causes an already wrapped exception on windows + nodejs 20.6.1
+// Running tests that spy on "istanbul-lib-report" serially solves this issue as after every test
+// the mocking is cleared (esmock.purge)
+test.serial("Report Coverage: Fronted config for watermarks", async (t) => {
 	const {sinon} = t.context;
 	const libReport = await esmock.p("istanbul-lib-report");
 	const coverageReporter = await esmock.p("../../../lib/coverage-reporter.js", {
@@ -224,7 +227,10 @@ test("Report Coverage: Fronted config for watermarks", async (t) => {
 	esmock.purge(coverageReporter);
 });
 
-test("Report Coverage: Fronted config for watermarks- overwrite just some properties", async (t) => {
+// ESM import + sinon.spy on "istanbul-lib-report" causes an already wrapped exception on windows + nodejs 20.6.1
+// Running tests that spy on "istanbul-lib-report" serially solves this issue as after every test
+// the mocking is cleared (esmock.purge)
+test.serial("Report Coverage: Fronted config for watermarks- overwrite just some properties", async (t) => {
 	const {sinon} = t.context;
 	const libReport = await esmock.p("istanbul-lib-report");
 	const coverageReporter = await esmock.p("../../../lib/coverage-reporter.js", {

--- a/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
+++ b/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
@@ -190,8 +190,8 @@ test("Report Coverage: Log warning if resource can not be found", async (t) => {
 
 test("Report Coverage: Fronted config for watermarks", async (t) => {
 	const {sinon} = t.context;
-	const libReport = await esmock("istanbul-lib-report");
-	const coverageReporter = await esmock("../../../lib/coverage-reporter.js", {
+	const libReport = await esmock.p("istanbul-lib-report");
+	const coverageReporter = await esmock.p("../../../lib/coverage-reporter.js", {
 		"istanbul-lib-report": libReport
 	});
 	const reportSpy = sinon.spy(libReport, "createContext");
@@ -219,12 +219,15 @@ test("Report Coverage: Fronted config for watermarks", async (t) => {
 	reportedWatermarks = reportSpy.lastCall.args[0].watermarks;
 	t.notDeepEqual(reportedWatermarks, modifiedWatermarks, "Watermarks state is not persisted");
 	t.deepEqual(reportedWatermarks, defaultWatermarks, "Default watermarks got used");
+
+	esmock.purge(libReport);
+	esmock.purge(coverageReporter);
 });
 
 test("Report Coverage: Fronted config for watermarks- overwrite just some properties", async (t) => {
 	const {sinon} = t.context;
-	const libReport = await esmock("istanbul-lib-report");
-	const coverageReporter = await esmock("../../../lib/coverage-reporter.js", {
+	const libReport = await esmock.p("istanbul-lib-report");
+	const coverageReporter = await esmock.p("../../../lib/coverage-reporter.js", {
 		"istanbul-lib-report": libReport
 	});
 	const reportSpy = sinon.spy(libReport, "createContext");
@@ -242,4 +245,7 @@ test("Report Coverage: Fronted config for watermarks- overwrite just some proper
 	t.deepEqual(reportedWatermarks, {...defaultWatermarks, ...{statements: [5, 10]}},
 		"Only 'statements' got updated. The rest is with default values."
 	);
+
+	esmock.purge(libReport);
+	esmock.purge(coverageReporter);
 });

--- a/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
+++ b/packages/middleware-code-coverage/test/unit/lib/coverage-reporter.js
@@ -3,56 +3,58 @@ import sinon from "sinon";
 import coverageReporter from "../../../lib/coverage-reporter.js";
 import {createInstrumentationConfig} from "../../../lib/util.js";
 
-const globalCoverageMap = {
-	"/resources/Control1.js": {
-		"path": "/resources/Control1.js",
-		"statementMap": {
-			"0": {
-				"start": {
-					"line": 7,
-					"column": 0
+const coverageData = {
+	coverage: {
+		"/resources/Control1.js": {
+			"path": "/resources/Control1.js",
+			"statementMap": {
+				"0": {
+					"start": {
+						"line": 7,
+						"column": 0
+					},
+					"end": {
+						"line": 31,
+						"column": 3
+					}
 				},
-				"end": {
-					"line": 31,
-					"column": 3
+				"1": {
+					"start": {
+						"line": 11,
+						"column": 17
+					},
+					"end": {
+						"line": 11,
+						"column": 26
+					}
+				},
+				"2": {
+					"start": {
+						"line": 17,
+						"column": 18
+					},
+					"end": {
+						"line": 28,
+						"column": 2
+					}
+				},
+				"3": {
+					"start": {
+						"line": 19,
+						"column": 3
+					},
+					"end": {
+						"line": 21,
+						"column": 4
+					}
 				}
 			},
-			"1": {
-				"start": {
-					"line": 11,
-					"column": 17
-				},
-				"end": {
-					"line": 11,
-					"column": 26
-				}
-			},
-			"2": {
-				"start": {
-					"line": 17,
-					"column": 18
-				},
-				"end": {
-					"line": 28,
-					"column": 2
-				}
-			},
-			"3": {
-				"start": {
-					"line": 19,
-					"column": 3
-				},
-				"end": {
-					"line": 21,
-					"column": 4
-				}
-			}
-		},
-		"fnMap": {},
-		"branchMap": {},
-		"s": {},
-		"f": {},
-		"b": {}
+			"fnMap": {},
+			"branchMap": {},
+			"s": {},
+			"f": {},
+			"b": {}
+		}
 	}
 };
 
@@ -98,7 +100,23 @@ test("Report Coverage", async (t) => {
 	};
 
 	const config = await createInstrumentationConfig();
-	const report = await coverageReporter(globalCoverageMap, config, mockedResource);
+	const report = await coverageReporter(coverageData, config, mockedResource);
+	t.deepEqual(report, expectedConfig);
+});
+
+test("Report Coverage (old structure)", async (t) => {
+	const expectedConfig = {
+		availableReports: [{
+			destination: "html/",
+			report: "html"
+		}],
+		coverageMap: [
+			"/resources/Control1.js"
+		],
+	};
+
+	const config = await createInstrumentationConfig();
+	const report = await coverageReporter(coverageData.coverage, config, mockedResource);
 	t.deepEqual(report, expectedConfig);
 });
 
@@ -121,7 +139,7 @@ test("Report Coverage: lcov reporter", async (t) => {
 			"reporter": ["lcov"]
 		}
 	});
-	const report = await coverageReporter(globalCoverageMap, config, mockedResource);
+	const report = await coverageReporter(coverageData, config, mockedResource);
 	t.deepEqual(report, expectedConfig);
 });
 
@@ -149,7 +167,7 @@ test("Report Coverage: Log warning if resource can not be found", async (t) => {
 		warn: warnLogStub
 	};
 	const config = await createInstrumentationConfig();
-	const report = await coverageReporter(globalCoverageMap, config, mockedResource, log);
+	const report = await coverageReporter(coverageData, config, mockedResource, log);
 
 	t.is(warnLogStub.callCount, 1);
 	t.is(warnLogStub.getCall(0).args[0],


### PR DESCRIPTION
This feature enables the extension of default or ui5.yaml's Istanbul configuration, so that certain settings could be adjusted from the frontend.

JIRA: CPOUI5FOUNDATION-709