### PR TITLE
fix(infra): downgrade to node v20.5.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Unit and Integration
     strategy:
       matrix:
-        version: [16, 18, 20]
+        version: [16, 18, 20.5]
         os: [ubuntu-22.04, windows-2022, macos-13]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This fix is needed in order to be able to have green tests. Currently Node.js v20.6 (which is the most recent one) has some issues with babel and esmock fails.