### PR TITLE
ci(release-please): add check for empty 'paths_released' value

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,7 @@ jobs:
         path: packages/${{inputs.package-folder}}
   publish-package:
     needs: pull-request
-    if: ${{needs.pull-request.outputs.releases_created}}
+    if: ${{needs.pull-request.outputs.releases_created && toJson(fromJson(needs.pull-request.outputs.paths_released)) != '[]'}}
     runs-on: ubuntu-22.04
     strategy:
       matrix:


### PR DESCRIPTION
Matrix config throws an error when an empty array is used. Therefore add a check for that case.

See https://github.com/SAP/ui5-tooling-extensions/actions/runs/8174526140