### PR TITLE
ci(commitlint): Fix exclusion for release commit

### DIFF
--- a/.commitlintrc.mjs
+++ b/.commitlintrc.mjs
@@ -29,6 +29,6 @@ export default {
 	},
 	ignores: [
 		// Ignore release commits, as their subject doesn't start with an uppercase letter
-		(message) => message.startsWith("release: v"),
+		(message) => message.startsWith("release: "),
 	]
 };


### PR DESCRIPTION
Release commit contains module name `release: middleware-code-coverage v1.0.0`. Therefore exclusion has to be adjusted.