### PR TITLE
ci: Upgrade used OS and Node versions

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   checks:
     name: Linting, dependency check and unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
     - uses: actions/checkout@v4

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   stale:
     name: Flag and close stale issues
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   pull-request:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       releases_created: ${{steps.release.outputs.releases_created}}
       paths_released: ${{steps.release.outputs.paths_released}}
@@ -32,7 +32,7 @@ jobs:
   publish-package:
     needs: pull-request
     if: ${{needs.pull-request.outputs.releases_created && toJson(fromJson(needs.pull-request.outputs.paths_released)) != '[]'}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
     strategy:
@@ -41,10 +41,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Use Node.js LTS 20.x
+    - name: Use Node.js LTS 22.x
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 22.x
     - name: Publish to NPM
       env:
         NPM_TOKEN: ${{secrets.NPM_UI5BOT}}

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   compliance-check:
     name: Compliance Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Execute REUSE Compliance Check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         version: [20, 22]
-        os: [ubuntu-22.04, windows-2022, macos-14]
+        os: [ubuntu-24.04, windows-2025, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
 
@@ -43,7 +43,7 @@ jobs:
         ui5-cli: [
           "latest-3"
         ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
 
     - uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
     - name: Use Node.js LTS
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 22.x
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
- Uses latest OS (macos, ubuntu and windows)
- Upgrade Node.js to current active version 22

**Note**: Default test execution still uses Node.js v20.11.0 because it is the minimal required Node.js version for this package