### PR TITLE
ci(release-please): Migrate to googleapis/release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
       releases_created: ${{steps.release.outputs.releases_created}}
       paths_released: ${{steps.release.outputs.paths_released}}
     steps:
-    - uses: google-github-actions/release-please-action@v4
+    - uses: googleapis/release-please-action@v4
       id: release
       with:
         token: ${{secrets.GH_OPENUI5BOT}}


### PR DESCRIPTION
GitHub action "google-github-actions/release-please-action" is deprecated in favor of "googleapis/release-please-action"
See https://github.com/googleapis/release-please-action
