### PR TITLE
ci: Fail-fast "npm ci" if deps require unsupported node version

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: 20.11.0
 
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --engine-strict # --engine-strict is used to fail-fast if deps require node versions unsupported by the repo
 
     - name: Perfrom ESLint check
       run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         node-version: ${{ matrix.version }}
 
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --engine-strict # --engine-strict is used to fail-fast if deps require node versions unsupported by the repo
 
     - name: Run unit tests
       run: npm run test:unit:coverage
@@ -57,7 +57,7 @@ jobs:
         node-version: 22.x
 
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --engine-strict # --engine-strict is used to fail-fast if deps require node versions unsupported by the repo
 
     - name: Install @ui5/cli ${{matrix.ui5-cli}}
       run: npm i -D @ui5/cli@${{matrix.ui5-cli}}


### PR DESCRIPTION
When upgrading a dependency to a newer version, it might require a different node version than before which could be unsupported by the repo. Unfortunately, this could be easily overseen.

This PR adds the flag --engine-strict to the dependency installation step during the GH Actions job. Incase such a version requirement change, this flag will now fail-fast the job which should attract attention.