### PR TITLE
ci: Add engine compatibility check for PRs (external package)

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -25,7 +25,10 @@ jobs:
         node-version: 20.11.0
 
     - name: Install dependencies
-      run: npm ci --engine-strict # --engine-strict is used to fail-fast if deps require node versions unsupported by the repo
+      run: npm ci
+
+    - name: Check Node.js engine compatibility
+      run: npm run check-engine
 
     - name: Perfrom ESLint check
       run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@commitlint/cli": "^20.4.2",
 				"@commitlint/config-conventional": "^20.4.2",
 				"@ui5/cli": "^4.0.46",
+				"check-engine-light": "0.4.0",
 				"husky": "^9.1.7",
 				"knip": "^5.85.0",
 				"licensee": "^11.1.1"
@@ -9688,6 +9689,26 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/check-engine-light": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/check-engine-light/-/check-engine-light-0.4.0.tgz",
+			"integrity": "sha512-hZzy5cbJg52nDGgyiNDVpjzrIo6V49lpFVJ7hJiGpbWs9in5mtpRMqdM1VPptab2QTkwYdac98PaXSBmQqh1Tg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"semver": "^7.7.3"
+			},
+			"bin": {
+				"check-engine-light": "lib/cli.js"
+			},
+			"engines": {
+				"node": "^20.11 || >=21.2"
+			},
+			"funding": {
+				"url": "https://ko-fi.com/textbook"
 			}
 		},
 		"node_modules/chownr": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		"@ui5/cli": "^4.0.46",
 		"husky": "^9.1.7",
 		"knip": "^5.85.0",
-		"licensee": "^11.1.1"
+		"licensee": "^11.1.1",
+		"check-engine-light": "0.4.0"
 	},
 	"scripts": {
 		"check-licenses": "licensee --errors-only",
@@ -42,6 +43,7 @@
 		"lint": "npm run lint --workspaces --if-present",
 		"lint:commit": "commitlint -e",
 		"prepare": "node ./.husky/skip.js || husky",
+		"check-engine": "check-engine-light .",
 		"test": "npm run test --workspaces --if-present && npm run knip",
 		"test:unit": "npm run test:unit --workspaces --if-present",
 		"test:unit:coverage": "npm run test:unit:coverage --workspaces --if-present",


### PR DESCRIPTION
JIRA: CPOUI5FOUNDATION-1225

check-engine-light is run as a regular CI step — if all dependencies are compatible it exits silently, and if any are incompatible it exits with code 1, failing the build.