### PR TITLE
ci: Harden workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,13 +13,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   pull-request:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       releases_created: ${{steps.release.outputs.releases_created}}
       paths_released: ${{steps.release.outputs.paths_released}}
@@ -48,6 +49,8 @@ jobs:
       with:
         node-version: 24.x
     - name: Publish to npm
+      env:
+        PATH_RELEASED: ${{matrix.path_released}}
       run: |
-        cd ${{matrix.path_released}}
+        cd "$PATH_RELEASED"
         npm publish --workspaces false --access public


### PR DESCRIPTION
- Use github.event.pull_request.user.login instead of github.actor for
  dependabot bot check (immutable PR author vs spoofable event actor)
- Move release-please workflow-level write permissions to the job that
  needs them; default to permissions: {}
- Pass matrix.path_released via env var to avoid template injection
  into the run script
