### PR TITLE
ci: Add aggregator job for test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,20 @@ jobs:
 
     - name: Run integration tests
       run: npm run test:integration
+
+  # Aggregator so branch protection can require a single "Tests" check
+  # instead of every matrix combination.
+  tests:
+    name: Tests
+    needs: [test, test-ui5cli-matrix]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check matrix result
+      run: |
+        if [ "${{ needs.test.result }}" != "success" ] || \
+           [ "${{ needs.test-ui5cli-matrix.result }}" != "success" ]; then
+          echo "test: ${{ needs.test.result }}"
+          echo "test-ui5cli-matrix: ${{ needs.test-ui5cli-matrix.result }}"
+          exit 1
+        fi


### PR DESCRIPTION
Add a 'Tests' job that depends on both matrix jobs (test and
test-ui5cli-matrix) so branch protection can require a single check
instead of every matrix combination. The matrix rows remain visible in
the PR checks list; only the required-check surface collapses.

'if: always()' ensures the aggregator still runs when matrix cells fail,
so a failure surfaces as 'failed' rather than 'skipped'.
